### PR TITLE
Add force parameter for poking disabled tasks

### DIFF
--- a/api/abstract-api.js
+++ b/api/abstract-api.js
@@ -30,9 +30,10 @@ module.exports = function hamsters(run, optionsList) {
     });
   }
 
-  function poke(names) {
+  function poke(namesParam, forceParam) {
+    const [names, force,] = getPokeOptions(namesParam, forceParam);
     horde.filter(byNames(names)).forEach(function(hamster) {
-      hamster.poke();
+      hamster.poke(force);
     });
     return api;
   }
@@ -126,8 +127,8 @@ function hamster(hordeEmitter, run, options) {
     next = setTimeout(run.bind(null, ctx, emitter, factory, reschedule), delay).unref();
   }
 
-  function poke() {
-    if (!enabled || stopping || running) return;
+  function poke(force) {
+    if ((!enabled && !force) || stopping || running) return;
     debug('Poking %s', name);
     var ctx = { name: name, run: uuid(), iteration: iteration++, };
     var reschedule = next ? schedule.bind(null, interval) : function() {};
@@ -171,4 +172,9 @@ function getDuration(duration, defaultValue) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
   return duration;
+}
+
+function getPokeOptions(names, force) {
+  if (typeof names === 'boolean' && force === undefined) return [undefined, names,];
+  return [names, force,];
 }

--- a/test/callback-api.test.js
+++ b/test/callback-api.test.js
@@ -253,6 +253,16 @@ describe('Callback API', function() {
     }, 100);
   });
 
+  it('should poke disabled tasks with force parameter', function(done) {
+    p = pipsqueak([
+      { task: task, interval: '50ms', disabled: true, },
+    ]).poke(true);
+    setTimeout(function() {
+      assert.equal(executions, 1);
+      done();
+    }, 100);
+  });
+
   it('should not poke stopped tasks', function(done) {
     p = pipsqueak([
       { task: task, interval: '50ms', },

--- a/test/promise-api.test.js
+++ b/test/promise-api.test.js
@@ -249,6 +249,16 @@ describe('Promise API', function() {
     }, 100);
   });
 
+  it('should poke disabled tasks with force parameter', function(done) {
+    p = pipsqueak([
+      { factory: factory, interval: '50ms', disabled: true, },
+    ]).poke(undefined, true);
+    setTimeout(function() {
+      assert.equal(executions, 1);
+      done();
+    }, 100);
+  });
+
   it('should not poke stopped tasks', function(done) {
     p = pipsqueak([
       { factory: factory, interval: '50ms', },

--- a/test/synchronous-api.test.js
+++ b/test/synchronous-api.test.js
@@ -216,6 +216,16 @@ describe('Synchronous API', function() {
     }, 100);
   });
 
+  it('should poke disabled tasks with force parameter', function(done) {
+    p = pipsqueak([
+      { task: task, interval: '50ms', disabled: true, },
+    ]).poke(true);
+    setTimeout(function() {
+      assert.equal(executions, 1);
+      done();
+    }, 100);
+  });
+
   it('should not poke stopped tasks', function(done) {
     p = pipsqueak([
       { task: task, interval: '50ms', },


### PR DESCRIPTION
This adds a force parameter to enable poking of disabled tasks. The `poke` method for a hamster horde already took an optional list of hamster `names`, so I have it take two arguments and check the types. If the first argument is boolean and the second argument is `undefined`, we assume that the first argument was really the `force` parameter and that there is no list of `names`, otherwise we assume that the arguments are `names` and `force` respectively.

This will probably require a minor version bump.